### PR TITLE
Micro-semi Mi-V tutorial - Correcting Load Script Command

### DIFF
--- a/source/tutorials/miv-example.rst
+++ b/source/tutorials/miv-example.rst
@@ -42,7 +42,7 @@ The provided script creates a single machine and loads a sample LiteOS-based app
 
 To run a script, use the ``include`` command (or ``i``, for short), with a path to the script to load, prepended with the ``@`` sign, like this::
 
-    include @scripts/single-node/miv.repl
+    include @scripts/single-node/miv.resc
 
 After the script is loaded, you will see a new terminal - a UART window opened by the ``showAnalyzer`` command.
 


### PR DESCRIPTION
Under the "Loading our setup" section the current command led to a file that did not exist. Modified to be more consistent with above sections.

Changed miv.repl to miv.resc