### PR TITLE
Fix typo in USB/IP tutorial

### DIFF
--- a/source/tutorials/usbip.rst
+++ b/source/tutorials/usbip.rst
@@ -74,9 +74,9 @@ Attaching exported device to host
 
 The next step is to attach the exported virtual USB device to the host machine::
 
-    $ sudo usbip attach -r 127.0.0.1 -d 1-0
+    $ sudo usbip attach -r 127.0.0.1 -b 1-0
 
-Note that the ``-d`` argument must match the device id returned by the ``usb list`` command.
+Note that the ``-b`` argument must match the device id returned by the ``usb list`` command.
 
 A new USB mouse should be now visible in the host.
 Confirm it by reading the system logs::
@@ -194,7 +194,7 @@ Use it on your host machine
 
 Import Fomu on the host::
 
-    $ sudo usbip attach -r 127.0.0.1 -d 1-0
+    $ sudo usbip attach -r 127.0.0.1 -b 1-0
 
 Upload software using ``dfu-util``::
 


### PR DESCRIPTION
I found a small typo in USB/IP tutorial on the page. I have tried the flow described in the manual and everything worked as expected despite attaching the exported device to host. In line 
sudo usbip attach -r 127.0.0.1 -d 1-0 
the last -d argument is misleading as it should be -b like --busid as stated on its manual page http://manpages.ubuntu.com/manpages/xenial/man1/usbip.8.html. If I change this flag, all the rest works as expected. 