### PR TITLE
Fix typo "LogAllPeripheralsAccesses" command in logger.rst

### DIFF
--- a/source/basic/logger.rst
+++ b/source/basic/logger.rst
@@ -85,7 +85,7 @@ Now, whenever the CPU tries to read or write to this peripheral, you will see a 
 
 To enable logging access to all peripherals, run::
 
-    (machine-0) sysbus LogAllPeripheralsAccesses true
+    (machine-0) sysbus LogAllPeripheralsAccess true
 
 Creating a trace of the execution
 '''''''''''''''''''''''''''''''''


### PR DESCRIPTION
Hi 

I found an error in the command in `logger.rst` and am reporting it.

```
(machine-0) sysbus LogAllPeripheralsAccesses true
There was an error executing command 'sysbus LogAllPeripheralsAccesses true'
sysbus does not provide a field, method or property LogAllPeripheralsAccesses.
(machine-0) sysbus LogAllPeripheralsAccess true
(machine-0) 
```

Renode, version 1.12.0.31957 (be98f0f3-202203081627)

ref.

https://github.com/renode/renode-infrastructure/blob/ae012ba4401a6f7ba94cd38b10c8c59770185405/src/Emulator/Main/Peripherals/Bus/SystemBus.cs#L165